### PR TITLE
Template 表示/有効化切替が新スキーマ修正及びダッシュボード画面の文言修正

### DIFF
--- a/src/components/settings/TemplateItem.jsx
+++ b/src/components/settings/TemplateItem.jsx
@@ -11,13 +11,13 @@ export const TemplateItem = ({ template, onActivate, onEdit, onDelete }) => {
 							<input
 								type="radio"
 								name="activeTemplate"
-								checked={template.isActive}
+								checked={template.is_active === 1}
 								onChange={() => onActivate(template.id)}
 								className="w-4 h-4 text-blue-600 focus:ring-blue-500"
 							/>
 							<span className="text-sm font-medium text-gray-700">有効化</span>
 						</div>
-						{template.isActive && (
+						{template.is_active === 1 && (
 							<span className="bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full">
 								有効
 							</span>
@@ -27,14 +27,14 @@ export const TemplateItem = ({ template, onActivate, onEdit, onDelete }) => {
 					{/* テンプレート内容 */}
 					<div className="bg-gray-50 p-4 rounded-lg mb-3">
 						<pre className="text-sm text-gray-800 whitespace-pre-wrap font-mono">
-							{template.content}
+							{template.Template}
 						</pre>
 					</div>
 
 					{/* 日付情報 */}
 					<div className="flex gap-4 text-xs text-gray-500">
-						<span>作成日: {template.createdAt}</span>
-						<span>更新日: {template.updatedAt}</span>
+						<span>作成日: {template.created_at}</span>
+						<span>更新日: {template.updated_at}</span>
 					</div>
 				</div>
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -30,7 +30,7 @@ const Dashboard = () => {
 			id: "stats-1",
 			type: "status",
 			label: "Qiita記事チェック",
-			value: "15分毎実行",
+			value: "8, 12, 20時に実行",
 			valueColor: "text-blue-600",
 		},
 		{
@@ -63,6 +63,7 @@ const Dashboard = () => {
 			time: new Date(post.created_at).toLocaleTimeString("ja-JP", {
 				hour: "2-digit",
 				minute: "2-digit",
+				timeZone: "Asia/Tokyo",
 			}),
 			title: post.title,
 			author: post.author || "不明",


### PR DESCRIPTION
## Why
この PR が発生した背景
- バックエンド/API から返るテンプレートオブジェクトのプロパティが `camelCase` から `snake_case`（かつ一部数値化）へ変更されたため、フロント側の参照がずれていた
- ダッシュボードのジョブ実行スケジュール表示が仕様変更（毎15分→「8, 12, 20時」）に追随していなかった
- 投稿時刻の表示が環境/ブラウザのタイムゾーンに依存しており、JST での統一表示が必要になった

resolves #<Issue 番号>

## What
変更の目的を記載
- Template 表示/有効化切替が新スキーマ（`is_active`, `created_at`, `updated_at`, `Template`）で正しく動くようにする
- Dashboard のステータスカード文言を最新仕様に合わせる
- 投稿一覧の時刻表示を JST（Asia/Tokyo）で安定化

## How
変更内容を記載
- `src/components/settings/TemplateItem.jsx`
  - `checked={template.isActive}` → `checked={template.is_active === 1}` に変更（数値フラグ対応）
  - 有効バッジの条件を `template.is_active === 1` に変更
  - 本文参照を `template.content` → `template.Template` に変更（API フィールド名に合わせる）
  - 日付表示を `createdAt/updatedAt` → `created_at/updated_at` に変更
- `src/pages/Dashboard.jsx`
  - ステータスカードの実行スケジュール表示を「15分毎実行」→「8, 12, 20時に実行」に更新
  - `toLocaleTimeString` に `timeZone: "Asia/Tokyo"` を追加し、JST での一貫表示を保証

## Test
テスト方法を記載
- TemplateItem
  - モックデータ `{ is_active: 1, Template: "…" }` を与えた時にラジオが ON、かつ「有効」バッジが表示されること
  - `{ is_active: 0 }` でラジオ OFF・バッジ非表示であること
  - テンプレート本文が `Template` フィールドの内容で表示されること
  - 作成日/更新日が `created_at` / `updated_at` の値で表示されること
- Dashboard
  - ステータスカードに「8, 12, 20時に実行」と表示されること
  - `post.created_at` に UTC を渡した場合でも、表示時刻が JST（例：`2025-08-26T00:30:00Z` → 「09:30」）になること
- 回帰確認
  - 有効化ラジオの `onChange` で `onActivate(template.id)` が呼ばれること
  - 既存の他コンポーネントに破壊的変更がないこと（画面表示・操作確認）
